### PR TITLE
Change HTTP to HTTPS links (fixes #7)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <title>Chicago Residential Parking Zones</title>
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
     <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
-    <link rel="shortcut icon" href="http://cartodb.com/assets/favicon.ico" />
+    <link rel="shortcut icon" href="https://carto.com/assets/favicon.ico" />
     <style>
       html, body, #map {
         height: 100%;
@@ -16,17 +16,17 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.11/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.11/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.11/cartodb.js"></script>
+    <script src="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.11/cartodb.js"></script>
 
     <script>
       function main() {
-        cartodb.createVis('map', 'http://jkalov.cartodb.com/api/v2/viz/d52e0db0-8654-11e4-9a46-0e9d821ea90d/viz.json', {
+        cartodb.createVis('map', 'https://jkalov.cartodb.com/api/v2/viz/d52e0db0-8654-11e4-9a46-0e9d821ea90d/viz.json', {
             shareable: true,
             title: true,
             description: true,


### PR DESCRIPTION
Apparently some of the static CartoDB TLS links are by Fastly CDN
